### PR TITLE
Update install-kaltura-redhat-based.md

### DIFF
--- a/doc/install-kaltura-redhat-based.md
+++ b/doc/install-kaltura-redhat-based.md
@@ -35,8 +35,7 @@ For nightly builds use:
 ```
 For stable updates:
 ```bash
-\\# rpm -ihv
-http://54.211.235.142/releases/stable/RPMS/noarch/kaltura-release.noarch.rpm
+\\# rpm -ihv http://54.211.235.142/releases/stable/RPMS/noarch/kaltura-release.noarch.rpm
 ```
 
 ###### Install the Kaltura Packages


### PR DESCRIPTION
Removed carriage return in rpm command which could have made it appear rpm -ihv was 2 commands
