### PR TITLE
MySQL setting remote root password + typo

### DIFF
--- a/doc/rpm-cluster-deployment-instructions.md
+++ b/doc/rpm-cluster-deployment-instructions.md
@@ -128,13 +128,19 @@ Please note that currently, only MySQL 5.1 is supported, we recommend using the 
 # /opt/kaltura/bin/kaltura-mysql-settings.sh
 # mysql_secure_installation
 ```
-**Make sure to say Y** for the `mysql_secure_install` install, and follow through all the mysql install questions before continuing further.    
-Failing to properly run `mysql_secure_install` will cause the kaltura mysql user to run without proper permissions to access your mysql DB.    
+**Make sure to say Y** for the `mysql_secure_installation` install, and follow through all the mysql install questions before continuing further.    
+Failing to properly run `mysql_secure_installation` will cause the kaltura mysql user to run without proper permissions to access your mysql DB.    
 ```
 # mysql -uroot -pYOUR_DB_ROOT_PASS
 mysql> GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
 mysql> FLUSH PRIVILEGES;
 ```
+Remote root user should have an access to the mysql DB during the installation of the front and batch servers.
+Run:
+```
+mysql> SET PASSWORD FOR 'root'@'%' = PASSWORD('YOUR_DB_ROOT_PASS');
+```
+Remove the remote root access to your MySQL DB for security reasons after Kaltura cluster installation.
 
 #### MySQL Replication and Scaling
 Scaling MySQL is an art on it's own. There are two aspects to it: Replication (having data live in more than one MySQL server for redundency and read scaling) and setting up read slaves.    


### PR DESCRIPTION
1. Remote root user accessing the DB during front and batch servers installation. Password for root@% should be set. And removed afterwards.
2. Typo in 'mysql_secure_installation` description.
