### PR TITLE
Timeouts patch

### DIFF
--- a/chef-repo/cookbooks/kaltura/recipes/batch.rb
+++ b/chef-repo/cookbooks/kaltura/recipes/batch.rb
@@ -23,6 +23,7 @@ template "/etc/yum.repos.d/kaltura.repo" do
 end
 package "kaltura-batch" do
   action :install
+  Chef::Config[:yum_timeout] = 3600
  end
 #%w{ apr apr-util lynx }.each do |pkg|
 #  package pkg do

--- a/chef-repo/cookbooks/kaltura/recipes/dwh.rb
+++ b/chef-repo/cookbooks/kaltura/recipes/dwh.rb
@@ -7,6 +7,7 @@ template "/etc/yum.repos.d/kaltura.repo" do
 end
 package "kaltura-dwh" do
   action :install
+  Chef::Config[:yum_timeout] = 3600
  end
 #%w{ apr apr-util lynx }.each do |pkg|
 #  package pkg do

--- a/chef-repo/cookbooks/kaltura/recipes/front.rb
+++ b/chef-repo/cookbooks/kaltura/recipes/front.rb
@@ -8,6 +8,7 @@ end
 log "Installing Kaltura front"
 package "kaltura-front" do
   action :install
+  Chef::Config[:yum_timeout] = 3600
  end
 %w{ kaltura-front kaltura-widgets kaltura-html5lib kaltura-html5-studio }.each do |pkg|
   package pkg do


### PR DESCRIPTION
Some modules needs more time to run when them are being installed by
chef, with this patch I get no timeouts that cancels my install.