### PR TITLE
Hostname should be used for n+1 sphinx support

### DIFF
--- a/RPM/scripts/postinst/kaltura-sphinx-config.sh
+++ b/RPM/scripts/postinst/kaltura-sphinx-config.sh
@@ -61,7 +61,7 @@ trap 'my_trap_handler "${LINENO}" ${$?}' ERR
 send_install_becon `basename $0` $ZONE install_start 0 
 mkdir -p $LOG_DIR/sphinx/data $APP_DIR/cache//sphinx
 chown $OS_KALTURA_USER.$OS_KALTURA_USER $APP_DIR/cache/sphinx $LOG_DIR/sphinx/data $BASE_DIR/sphinx
-echo "sphinxServer = $SPHINX_HOST" > /opt/kaltura/app/configurations/sphinx/populate/`hostname`.ini
+echo "sphinxServer = `hostname`" > /opt/kaltura/app/configurations/sphinx/populate/`hostname`.ini
 /etc/init.d/kaltura-sphinx restart >/dev/null 2>&1
 /etc/init.d/kaltura-populate restart >/dev/null 2>&1
 ln -sf $BASE_DIR/app/configurations/monit/monit.avail/sphinx.rc $BASE_DIR/app/configurations/monit/monit.d/enabled.sphinx.rc


### PR DESCRIPTION
Unless we add n+1 support to the kaltura-sphinx-config.sh file and ask the end-user to identify the unique sphinx server number from the answer file, then we should merge this fix here. 
Note, the hostname used in the populate ini file must resolve to localhost for kaltura-populate to function, so we can't just put anything in there.