### PR TITLE
add new nginx aws auth module and sources

### DIFF
--- a/RPM/SPECS/kaltura-nginx.spec
+++ b/RPM/SPECS/kaltura-nginx.spec
@@ -46,12 +46,13 @@ Requires(pre): pwdutils
 %define nginx_secure_token_ver 1.1
 %define nginx_token_validate_ver 1.0.1
 %define nginx_vts_ver 0.1.9
+%define ngx_aws_auth_ver 2.0.0
 # end of distribution specific definitions
 
 Summary: High performance web server customized for Kaltura VOD
 Name: kaltura-nginx
 Version: 1.8.1
-Release: 5
+Release: 6
 Vendor: Kaltura inc.
 URL: http://nginx.org/
 
@@ -69,6 +70,7 @@ Source10: nginx-vod-module-%{nginx_vod_module_ver}.zip
 Source11: nginx-secure-token-module-%{nginx_secure_token_ver}.zip
 Source12: nginx-akamai-token-validate-module-%{nginx_token_validate_ver}.zip
 Source13: nginx-module-vts-v%{nginx_vts_ver}.zip
+Source14: ngx_aws_auth-%{ngx_aws_auth_ver}.zip
 #Patch1: nginx_kaltura.diff 
 
 License: 2-clause BSD-like license
@@ -104,6 +106,7 @@ unzip -o %{SOURCE12}
 
 unzip -o %{SOURCE13}
 
+unzip -o %{SOURCE14}
 
 %build
 ./configure \
@@ -146,6 +149,7 @@ unzip -o %{SOURCE13}
 	--add-module=./nginx-secure-token-module-%{nginx_secure_token_ver} \
 	--add-module=./nginx-akamai-token-validate-module-%{nginx_token_validate_ver} \
 	--add-module=./nginx-module-vts-%{nginx_vts_ver} \
+	--add-module=./ngx_aws_auth-%{ngx_aws_auth_ver} \
         $*
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/nginx-%{version}/objs/nginx \
@@ -189,6 +193,7 @@ make %{?_smp_mflags}
 	--add-module=./nginx-secure-token-module-%{nginx_secure_token_ver} \
 	--add-module=./nginx-akamai-token-validate-module-%{nginx_token_validate_ver} \
 	--add-module=./nginx-module-vts-%{nginx_vts_ver} \
+	--add-module=./ngx_aws_auth-%{ngx_aws_auth_ver} \
         $*
 make %{?_smp_mflags}
 
@@ -359,6 +364,9 @@ if [ $1 -ge 1 ]; then
         "Binary upgrade failed, please check nginx's error.log"
 fi
 %changelog
+* Fri May 20 2016 Anthony Drimones <anthony.drimones@kaltura.com> - 1.8.1-6
+- Add Nginx AWS Authentication module - 2.0.0
+
 * Sun May 8 2016 Jess Portnoy <jess.portnoy@kaltura.com> - 1.8.1-5
 - New Nginx vod module - 1.8
 

--- a/build/package_kaltura_nginx.sh
+++ b/build/package_kaltura_nginx.sh
@@ -35,6 +35,8 @@ wget $NGINX_VTS_URI -O$RPM_SOURCES_DIR/nginx-module-vts-$NGINX_VTS_VERSION.zip
 echo "Packaged into $RPM_SOURCES_DIR/nginx-module-vts-$NGINX_VTS_VERSION.zip"
 wget $NGINX_URI -O$RPM_SOURCES_DIR/kaltura-nginx-$NGINX_VERSION.tar.gz
 echo "Packaged into $RPM_SOURCES_DIR/kaltura-nginx-$NGINX_VERSION.tar.gz"
+wget $NGX_AWS_AUTH_URI -O$RPM_SOURCES_DIR/ngx_aws_auth-$NGX_AWS_AUTH_VERSION.zip
+echo "Packaged into $RPM_SOURCES_DIR/ngx_aws_auth-$NGX_AWS_AUTH_VERSION.zip"
 
 if [ -x "`which rpmbuild 2>/dev/null`" ];then
 	rpmbuild -ba $RPM_SPECS_DIR/kaltura-nginx.spec

--- a/build/sources.rc
+++ b/build/sources.rc
@@ -160,6 +160,10 @@ KALTURA_NGINX_SECURE_TOKEN_URI="https://github.com/kaltura/nginx-secure-token-mo
 NGINX_VERSION=1.8.1
 NGINX_URI="http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
+# Nginx AWS authentication module. Not pulling from source's repo due to 2.0.0 release not created yet, and don't want to use master.
+NGX_AWS_AUTH_VERSION="2.0.0"
+NGX_AWS_AUTH_URI="https://github.com/doubleshot/ngx_aws_auth/archive/$NGX_AWS_AUTH_VERSION.zip"
+
 # Kaltura Streaming lib build vars:
 KALTURA_MEDIASERVER_VERSION="3.2.0"
 KALTURA_MEDIASERVER_URI="https://github.com/kaltura/media-server/releases/download/rel-$KALTURA_MEDIASERVER_VERSION/KalturaWowzaServer-install-$KALTURA_MEDIASERVER_VERSION.zip"


### PR DESCRIPTION
- Adds new nginx ngx_aws_auth module for making authenticated calls to AWS. For example, pulling private S3 server-side encrypted objects.
- Until creator of ngx_aws_auth repo creates a formal 2.0.0 release, it will pull from my fork. 