### PR TITLE
Don't rely on having a pid for memcached

### DIFF
--- a/RPM/SOURCES/memcached.template.rc
+++ b/RPM/SOURCES/memcached.template.rc
@@ -1,5 +1,5 @@
 check process memcache
-    with pidfile "/var/run/memcached/memcached.pid"
+    with match "memcached"
     start program = "/sbin/service memcached start" with timeout 60 seconds
     stop program = "/sbin/service memcached stop"
 


### PR DESCRIPTION
depending on the os we might not have a pid file, so just checking for the process name might be more portable.