### PR TITLE
Lynx 12.11.0 vts update

### DIFF
--- a/RPM/SPECS/kaltura-nginx.spec
+++ b/RPM/SPECS/kaltura-nginx.spec
@@ -43,16 +43,16 @@ Requires(pre): pwdutils
 %define nginx_vod_module_ver 1.12
 %define nginx_secure_token_ver 1.1
 %define nginx_token_validate_ver 1.0.1
-%define nginx_vts_ver 0.1.11
+%define nginx_vts_ver 0.1.12
 %define nginx_rtmp_ver 1.1.10
-%define ngx_aws_auth_ver 2.0.1
+%define ngx_aws_auth_ver 2.1.0
 %define headers_more_nginx_ver 0.32
 # end of distribution specific definitions
 
 Summary: High performance web server customized for Kaltura VOD
 Name: kaltura-nginx
-Version: 1.10.2
-Release: 7
+Version: 1.10.3
+Release: 8
 Vendor: Kaltura inc.
 URL: http://nginx.org/
 

--- a/RPM/SPECS/kaltura-nginx.spec
+++ b/RPM/SPECS/kaltura-nginx.spec
@@ -43,7 +43,7 @@ Requires(pre): pwdutils
 %define nginx_vod_module_ver 1.12
 %define nginx_secure_token_ver 1.1
 %define nginx_token_validate_ver 1.0.1
-%define nginx_vts_ver 0.1.10
+%define nginx_vts_ver 0.1.11
 %define nginx_rtmp_ver 1.1.10
 %define ngx_aws_auth_ver 2.0.1
 %define headers_more_nginx_ver 0.32

--- a/build/sources.rc
+++ b/build/sources.rc
@@ -155,7 +155,7 @@ KALTURA_NGINX_VOD_URI="https://github.com/kaltura/nginx-vod-module/archive/$KALT
 KALTURA_NGINX_AKAMAI_TOKEN_VALIDATE_VERSION=1.0.1
 KALTURA_NGINX_AKAMAI_TOKEN_VALIDATE_URI="https://github.com/kaltura/nginx-akamai-token-validate-module/archive/$KALTURA_NGINX_AKAMAI_TOKEN_VALIDATE_VERSION.zip"
 
-NGINX_VTS_VERSION=v0.1.10
+NGINX_VTS_VERSION=v0.1.12
 NGINX_VTS_URI="https://github.com/vozlt/nginx-module-vts/archive/$NGINX_VTS_VERSION.zip"
 
 NGINX_RTMP_VERSION=v1.1.10
@@ -163,12 +163,12 @@ NGINX_RTMP_URI="https://github.com/arut/nginx-rtmp-module/archive/$NGINX_RTMP_VE
 
 KALTURA_NGINX_SECURE_TOKEN_VERSION=1.1
 KALTURA_NGINX_SECURE_TOKEN_URI="https://github.com/kaltura/nginx-secure-token-module/archive/$KALTURA_NGINX_SECURE_TOKEN_VERSION.zip"
-NGINX_VERSION=1.10.2
+NGINX_VERSION=1.10.3
 NGINX_URI="http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
 # Nginx AWS authentication module.
-NGX_AWS_AUTH_VERSION="2.0.1"
-NGX_AWS_AUTH_URI="https://github.com/kaltura/ngx_aws_auth/archive/$NGX_AWS_AUTH_VERSION.zip"
+NGX_AWS_AUTH_VERSION="2.1.0"
+NGX_AWS_AUTH_URI="https://github.com/anomalizer/ngx_aws_auth/archive/$NGX_AWS_AUTH_VERSION.zip"
 
 # Nginx headers more module
 HEADERS_MORE_NGINX_VERSION="v0.32"


### PR DESCRIPTION
Fix VTS worker process exited on signal 11
Sync with nginx upstream
Switch back to regular aws_auth upstream