### PR TITLE
Update get_kmc_swfs.php

### DIFF
--- a/RPM/scripts/postinst/get_kmc_swfs.php
+++ b/RPM/scripts/postinst/get_kmc_swfs.php
@@ -6,7 +6,11 @@ $clientConfig = null;
 require_once __DIR__ . '/init.php';
 
 $kmcUrl = $clientConfig->serviceUrl . 'kmc';
+stream_wrapper_restore('http');
+stream_wrapper_restore('https');
 $kmcHtmlContent = file_get_contents($kmcUrl);
+stream_wrapper_unregister('http');
+stream_wrapper_unregister('https');
 if(!$kmcHtmlContent)
 {
 	echo "Fetching URL [$kmcUrl] failed\n";


### PR DESCRIPTION
restoring http/https stream wrappers to avoid PHP warning - Unable to find the wrapper http/https

@jessp01 